### PR TITLE
Add helm Chart for adding PostgreSQL for Dawson app

### DIFF
--- a/dawson/postgresql/Chart.yaml
+++ b/dawson/postgresql/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v3
+name: postgres
+description: A Helm chart for PostgreSQL database
+type: application
+version: 0.1.0
+appVersion: 14.3.0
+dependencies:
+  - name: postgresql
+    repository: https://charts.bitnami.com/bitnami
+    version: 11.x.x
+keywords:
+  - database
+  - postgres
+home: https://github.com/chrizpy/kubernetes-app-deployment
+maintainers:
+  - name: Christoffer Akouri
+    url: https://github.com/chrizpy

--- a/dawson/postgresql/templates/storage_class.yaml
+++ b/dawson/postgresql/templates/storage_class.yaml
@@ -1,0 +1,6 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Values.global.storageClass }}
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer

--- a/dawson/postgresql/values.yaml
+++ b/dawson/postgresql/values.yaml
@@ -1,0 +1,11 @@
+resources:
+  requests:
+    memory: 2Gi
+    cpu: 500m
+
+global:
+  storageClass: "postgresql-storage"
+
+primary:
+  persistence:
+    size: 75Gi


### PR DESCRIPTION
This is the beginning of implementing a work app called "Dawson"
into a Kubernetes cluster.

Dawson has a few services that it needs to run, such as PostgreSQL.
I will be using helm to accomplish this, since I do not want to write
a bunch of extra .yml files if not needed, I trust bitnami with that.